### PR TITLE
Provide channels by having executeCell return fn

### DIFF
--- a/action-creators.js
+++ b/action-creators.js
@@ -1,0 +1,17 @@
+
+// A couple simple action creators we'll use in the real Agenda we're exploring
+export function updateCellOutputs(id, outputs) {
+  return {
+    type: 'UPDATE_CELL_OUTPUTS',
+    id,
+    outputs,
+  };
+}
+
+export function updateCellExecutionCount(id, count) {
+  return {
+    type: 'UPDATE_CELL_EXECUTION_COUNT',
+    id,
+    count,
+  };
+}

--- a/agenda.js
+++ b/agenda.js
@@ -11,13 +11,12 @@ import {
   updateCellOutputs,
 } from './action-creators';
 
-// Usage
+// Usage:
+// dispatch(executeCell(id,source)(channels))
 
 export function executeCell(id, source) {
   function execute(channels) {
     return Rx.Observable.create((subscriber) => {
-      // Assume we have channels... somehow...
-      // Tempted to make this return a function that passes in channels
       const { iopub, shell } = channels;
 
       if (!iopub || !shell) {

--- a/agenda.js
+++ b/agenda.js
@@ -11,7 +11,7 @@ import {
   updateCellOutputs,
 } from './action-creators';
 
-// Usage:
+// Usage, assuming using Fluorine
 // dispatch(executeCell(id,source)(channels))
 
 export function executeCell(id, source) {

--- a/agenda.js
+++ b/agenda.js
@@ -15,7 +15,7 @@ import {
 // dispatch(executeCell(id,source)(channels))
 
 export function executeCell(id, source) {
-  function execute(channels) {
+  return function executeCellOnChannels(channels) {
     return Rx.Observable.create((subscriber) => {
       const { iopub, shell } = channels;
 
@@ -68,11 +68,9 @@ export function executeCell(id, source) {
 
       shell.next(executeRequest);
 
-      return function disposed() {
+      return function executionDisposed() {
         subscriptions.forEach((sub) => sub.unsubscribe());
       };
     });
-  }
-
-  return execute;
+  };
 }

--- a/agenda.js
+++ b/agenda.js
@@ -6,88 +6,74 @@ import {
   msgSpecToNotebookFormat,
 } from './messaging';
 
+import {
+  updateCellExecutionCount,
+  updateCellOutputs,
+} from './action-creators';
 
-// A couple simple action creators we'll use in the real Agenda we're exploring
-export function updateCellOutputs(id, outputs) {
-  return {
-    type: 'UPDATE_CELL_OUTPUTS',
-    id,
-    outputs,
-  };
-}
-
-export function updateCellExecutionCount(id, count) {
-  return {
-    type: 'UPDATE_CELL_EXECUTION_COUNT',
-    id,
-    count,
-  };
-}
-
-// TODO: How do we get access to the channels we need here? Pass them in to
-// executeCell ?
-const channels = {
-  iopub: 'fake',
-  shell: 'also-fake',
-};
+// Usage
 
 export function executeCell(id, source) {
-  return Rx.Observable.create((subscriber) => {
-    // Assume we have channels... somehow...
-    // Tempted to make this return a function that passes in channels
-    const { iopub, shell } = channels;
+  function execute(channels) {
+    return Rx.Observable.create((subscriber) => {
+      // Assume we have channels... somehow...
+      // Tempted to make this return a function that passes in channels
+      const { iopub, shell } = channels;
 
-    if (!iopub || !shell) {
-      subscriber.error('kernel not connected');
-      subscriber.complete();
-      return () => {};
-    }
+      if (!iopub || !shell) {
+        subscriber.error('kernel not connected');
+        subscriber.complete();
+        return () => {};
+      }
 
-    // Track all of our subscriptions for full disposal
-    const subscriptions = [];
+      // Track all of our subscriptions for full disposal
+      const subscriptions = [];
 
-    const executeRequest = createExecuteRequest(source);
+      const executeRequest = createExecuteRequest(source);
 
-    // Limitation of the Subject implementation in enchannel
-    // we must shell.subscribe in order to shell.next
-    subscriptions.push(shell.subscribe(() => {}));
+      // Limitation of the Subject implementation in enchannel
+      // we must shell.subscribe in order to shell.next
+      subscriptions.push(shell.subscribe(() => {}));
 
-    // Set the current outputs to an empty list
-    subscriber.next(updateCellOutputs(id, new Immutable.List()));
+      // Set the current outputs to an empty list
+      subscriber.next(updateCellOutputs(id, new Immutable.List()));
 
-    const childMessages = iopub.childOf(executeRequest)
-                               .share();
+      const childMessages = iopub.childOf(executeRequest)
+                                 .share();
 
-    subscriptions.push(
-      childMessages.ofMessageType(['execute_input'])
-                 .pluck('content', 'execution_count')
-                 .first()
-                 .subscribe((ct) => {
-                   subscriber.next(updateCellExecutionCount(id, ct));
-                 })
-    );
+      subscriptions.push(
+        childMessages.ofMessageType(['execute_input'])
+                   .pluck('content', 'execution_count')
+                   .first()
+                   .subscribe((ct) => {
+                     subscriber.next(updateCellExecutionCount(id, ct));
+                   })
+      );
 
-    // Handle all the nbformattable messages
-    subscriptions.push(childMessages
-         .ofMessageType(['execute_result', 'display_data', 'stream', 'error', 'clear_output'])
-         .map(msgSpecToNotebookFormat)
-         // Iteratively reduce on the outputs
-         .scan((outputs, output) => {
-           if (output.output_type === 'clear_output') {
-             return new Immutable.List();
-           }
-           return outputs.push(Immutable.fromJS(output));
-         }, new Immutable.List())
-         // Update the outputs with each change
-         .subscribe(outputs => {
-           subscriber.next(updateCellOutputs(id, outputs));
-         })
-    );
+      // Handle all the nbformattable messages
+      subscriptions.push(childMessages
+           .ofMessageType(['execute_result', 'display_data', 'stream', 'error', 'clear_output'])
+           .map(msgSpecToNotebookFormat)
+           // Iteratively reduce on the outputs
+           .scan((outputs, output) => {
+             if (output.output_type === 'clear_output') {
+               return new Immutable.List();
+             }
+             return outputs.push(Immutable.fromJS(output));
+           }, new Immutable.List())
+           // Update the outputs with each change
+           .subscribe(outputs => {
+             subscriber.next(updateCellOutputs(id, outputs));
+           })
+      );
 
-    shell.next(executeRequest);
+      shell.next(executeRequest);
 
-    return function disposed() {
-      subscriptions.forEach((sub) => sub.unsubscribe());
-    };
-  });
+      return function disposed() {
+        subscriptions.forEach((sub) => sub.unsubscribe());
+      };
+    });
+  }
+
+  return execute;
 }


### PR DESCRIPTION
We need context of the current channels... somehow. This makes `executeCell` return a function that accepts the `channels` directly. Not sure what the best pattern is.

What I can say is that I really love agendas here for a few reasons:
- explicitly able to clean up those inner subscriptions
- no passing the dispatch in, we're emitting actions instead
- way simpler to test
- can cancel the agenda
- seems like it would map well with redux sagas (we're using observables with channels anyways) as well as with fluorine

/cc @jdfreder @philpl 
